### PR TITLE
Update encouragement

### DIFF
--- a/css/studyGuide.css
+++ b/css/studyGuide.css
@@ -57,8 +57,8 @@ label {
 
 /* mobile test completion rate pop-up*/
 .completionPopUp {
-    height: 25px;
-    width: 50px;
+    height: 100px;
+    width: 100px;
     border-radius:50%; 
     position: absolute;
     top: 50%;
@@ -67,6 +67,7 @@ label {
     margin-left: -100px;
     display: block;
     margin: 0 auto;
+    text-align: center;
 }
 
 

--- a/css/studyGuide.css
+++ b/css/studyGuide.css
@@ -55,6 +55,20 @@ label {
 	margin-top: 20px;
 }
 
+/* mobile test completion rate pop-up*/
+.completionPopUp {
+    height: 25px;
+    width: 50px;
+    border-radius:50%; 
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    margin-top: -100px;
+    margin-left: -100px;
+    display: block;
+    margin: 0 auto;
+}
+
 
 
 /*                  Final Grade Page UI      */

--- a/css/studyGuide.css
+++ b/css/studyGuide.css
@@ -7,6 +7,7 @@ main {
 .fixedElement {
     width: 100%; /*stretch the encouragement div across the entire app*/
     margin-top:  -13px;/*move encouragement div to below the nav*/
+    z-index: 2;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
             </div>    
         </header>
             <!-- encouragment animation area. Only show with tablets and higher views -->  
-            <div class="fixedElement col m12 show-on-medium-and-up orange lighten-3 z-depth-1" >  
+            <div class="fixedElement col m12 hide-on-small-only orange lighten-3 z-depth-1" >  
                 <p class="center target">{{encouragement}} </p>                 
             </div>             
         </div>

--- a/index.html
+++ b/index.html
@@ -60,8 +60,8 @@
               </nav>
             </div>    
         </header>
-            <!-- encouragment animation area -->  
-            <div class="fixedElement orange lighten-3 z-depth-1" >  
+            <!-- encouragment animation area. Only show with tablets and higher views -->  
+            <div class="fixedElement col m12 show-on-medium-and-up orange lighten-3 z-depth-1" >  
                 <p class="center target">{{encouragement}} </p>                 
             </div>             
         </div>

--- a/nav functions/scoreService.js
+++ b/nav functions/scoreService.js
@@ -7,7 +7,7 @@ myApp.factory('Score', [ function () {
     var completionBoard= {"showCompletion":true};
     var completionRate = {"numberOfQuestions":0, "numberOfQuestionsCompleted":0};
     
-    var positiveFeedBack = ["Good Job, Baby", "Besides chocolate, you are my favorite", "You are doing a Awesome job", "I love  you", "You can do it", "Get that A, Get that A", "You are the Best", "Super-smart, that's what you are", "Please Lord, help this child of mine", "If you need help, come get me", "I turned out liking you a lot more than I originally planned", "Good friends don't let you do stupid things...alone",];
+    var positiveFeedBack = ["Press the enter button to submit answer", "Good Job, Baby", "Besides chocolate, you are my favorite", "You are doing a Awesome job", "Press the enter button to submit answer", "I love  you", "You can do it", "Get that A, Get that A", "Press the enter button to submit answer", "You are the Best", "Super-smart, that's what you are", "Press the enter button to submit answer", "Please Lord, help this child of mine", "Press the enter button to submit answer", "If you need help, come get me", "I turned out liking you a lot more than I originally planned", "Good friends don't let you do stupid things...alone", "Press the enter button to submit answer"];
      
      return {
          

--- a/questions/questions.html
+++ b/questions/questions.html
@@ -68,7 +68,11 @@
             <a class="pulse btn btn-large orange darken-4 black-text" id="submit" ui-sref="finalGrade" ng-disabled= "enableFinishButton">
                 Final Grade
             </a>
-        </div>        
+        </div>
+        <!--show test compeletion rate in mobile view-->
+        <div class="show-on-small completionPopUp orange lighten-3 black-text flow-text">
+            <strong class="black-text ">Completed: {{currentCompletionRate| number: 0}}%</strong>
+        </div>
         
         
     </div>

--- a/questions/questions.html
+++ b/questions/questions.html
@@ -19,7 +19,7 @@
                 </div>
                 <!-- Show this div when app start for student to type answers-->
                 <div ng-show="takingTest">
-                    <div class="col m6 show-on-medium-and-up">
+                    <div class="col m6 hide-on-small-only">
                         <!-- Student click this button to submit answer and disable field/button-->
 						<!-- the clickable directive and attribute index allow the user to click the link causing the done() method and auto focus to the next textarea -->
                         <a clickable index="{{$index}}" class="waves-effect waves-light btn orange accent-3 black-text" ng-click="done($index, userAnswer)" ng-disabled="guide.completed==true">
@@ -27,11 +27,11 @@
                         </a> 
                     </div>
                     <!--The encouragement div under the questions only shows on mobile views.  -->
-                    <div class="col s9 show-on-small orange lighten-3 z-depth-1" >  
+                    <div class="col s12 hide-on-med-and-up flow-text" >  
                         <p class="center">{{encouragement}} </p>                 
                     </div>                    
                     <!-- Student click this button to submit reset answer-->
-                    <div class="col s3 m6 right-align">
+                    <div class="col s3 m6 right-align hide-on-small-only">
                         <input class="grey-text red lighten-5 btn" type="reset" ng-disabled="guide.completed==true">                    
                     </div>
                 </div>
@@ -70,7 +70,7 @@
             </a>
         </div>
         <!--show test compeletion rate in mobile view-->
-        <div class="show-on-small completionPopUp orange lighten-3 black-text flow-text">
+        <div class="hide-on-med-and-up completionPopUp orange-text flow-text" ng-show = "showCompletionRate">
             <strong class="black-text ">Completed: {{currentCompletionRate| number: 0}}%</strong>
         </div>
         

--- a/questions/questions.html
+++ b/questions/questions.html
@@ -19,15 +19,19 @@
                 </div>
                 <!-- Show this div when app start for student to type answers-->
                 <div ng-show="takingTest">
-                    <div class="col s6">
+                    <div class="col m6 show-on-medium-and-up">
                         <!-- Student click this button to submit answer and disable field/button-->
 						<!-- the clickable directive and attribute index allow the user to click the link causing the done() method and auto focus to the next textarea -->
                         <a clickable index="{{$index}}" class="waves-effect waves-light btn orange accent-3 black-text" ng-click="done($index, userAnswer)" ng-disabled="guide.completed==true">
                         Done                    
                         </a> 
                     </div>
+                    <!--The encouragement div under the questions only shows on mobile views.  -->
+                    <div class="col s9 show-on-small orange lighten-3 z-depth-1" >  
+                        <p class="center">{{encouragement}} </p>                 
+                    </div>                    
                     <!-- Student click this button to submit reset answer-->
-                    <div class="col s6 right-align">
+                    <div class="col s3 m6 right-align">
                         <input class="grey-text red lighten-5 btn" type="reset" ng-disabled="guide.completed==true">                    
                     </div>
                 </div>

--- a/questions/questions.html
+++ b/questions/questions.html
@@ -15,7 +15,7 @@
 					<!--The id attribute identify the question. -->
 					<!--The ng-disabled attribute changes this unique question's completed value to true, therefore disabling the done button below it -->
 					<!--The ng-keypress attribute allows the user to press the "enter" keyboard command that stimulates the done button below(submit answer and disable button) -->
-                    <textarea enter class="z-depth-1 materialize-textarea" ng-model="userAnswer" placeholder="Answers go here" required ng-disabled="guide.completed==true" id="{{$index + 1}}" ng-keypress="DoneWithKeyboardEnterCommand($event, $index, userAnswer)" tabindex="{{$index + 1}}"></textarea>                      
+                    <textarea enter class="z-depth-1 materialize-textarea" ng-model="userAnswer" placeholder="Answers go here. Enter button to submit" required ng-disabled="guide.completed==true" id="{{$index + 1}}" ng-keypress="DoneWithKeyboardEnterCommand($event, $index, userAnswer)" tabindex="{{$index + 1}}"></textarea>                      
                 </div>
                 <!-- Show this div when app start for student to type answers-->
                 <div ng-show="takingTest">

--- a/questions/questions.html
+++ b/questions/questions.html
@@ -28,7 +28,7 @@
                     </div>
                     <!--The encouragement div under the questions only shows on mobile views.  -->
                     <div class="col s12 hide-on-med-and-up flow-text" >  
-                        <p class="center">{{encouragement}} </p>                 
+						<p class="grey-text">{{guide.encouragement}}	</p>               
                     </div>                    
                     <!-- Student click this button to submit reset answer-->
                     <div class="col s3 m6 right-align hide-on-small-only">

--- a/questions/questionsController.js
+++ b/questions/questionsController.js
@@ -1,4 +1,4 @@
-myApp.controller('questionsController',  function($scope, TestData, Score){  
+myApp.controller('questionsController',  function($scope,$window, TestData, Score){  
     
     //initialize varible use to show the "done" and "reset' buttons on the questions page
     $scope.takingTest = true;
@@ -29,6 +29,9 @@ myApp.controller('questionsController',  function($scope, TestData, Score){
     
     //initialize the variable use to disable "check your answers" button based on the number of test questions to ensure student complete form
     $scope.completeEveryQuestion = true;
+    
+    //variable link to the mobile completion rate popup div
+    $scope.showCompletionRate = false;
 
     //function to get student answer to a question saved to the question object it came from    
     $scope.done = function(index, answer){
@@ -46,6 +49,8 @@ myApp.controller('questionsController',  function($scope, TestData, Score){
             $scope.completeEveryQuestion = false;
             
         }
+        
+        $scope.showCompletionRatePopUp();
     }
 	
 	//tip from https://www.w3schools.com/jsref/tryit.asp?filename=tryjsref_event_key_keycode
@@ -57,8 +62,20 @@ myApp.controller('questionsController',  function($scope, TestData, Score){
 	}
     
     //method to show the completion rate every 3 questions answer for a few seconds.
-    $scope.showCompletionPopUP = function(){
+    $scope.showCompletionRatePopUp = function(){
+        $scope.updatedNumber = Score.getQuestionsAnswered();
+        console.log($scope.updatedNumber);
+        if(($scope.updatedNumber % 3)!==0){
+            $scope.showCompletionRate = true;
+            $window.setTimeout($scope.hideCompletionRatePopUp, 1000); 
+        }
 
+        console.log($scope.updatedNumber % 3);
+    }
+    
+    
+    $scope.hideCompletionRatePopUp = function(){
+        $scope.showCompletionRate = false;
     }
     
     

--- a/questions/questionsController.js
+++ b/questions/questionsController.js
@@ -56,6 +56,11 @@ myApp.controller('questionsController',  function($scope, TestData, Score){
 			$scope.done(index, answer);	//run the done method
 	}
     
+    //method to show the completion rate every 3 questions answer for a few seconds.
+    $scope.showCompletionPopUP = function(){
+
+    }
+    
     
     //function to switch student from taking test to grading of the test
     $scope.checkAnswers = function(){

--- a/questions/questionsController.js
+++ b/questions/questionsController.js
@@ -14,10 +14,13 @@ myApp.controller('questionsController',  function($scope,$window, TestData, Scor
     
     //get test name from the TestData service to be displayed 
     $scope.studyTestName = TestData.getTestName("scienceChp1");
+	
+	//Update the chosen test with encouragement and instructions
+	TestData.upgradeData($scope.currentTest);	
     
     //get test data from the TestData service to be displayed 
-    $scope.studyQuestions = TestData.getData("scienceChp1");    
-    
+    $scope.studyQuestions = TestData.getData("scienceChp1"); 
+	
     //determine how many questions are in the test for grading
     $scope.numberOfTestQuestions = $scope.studyQuestions.length;
     

--- a/questions/questionsService.js
+++ b/questions/questionsService.js
@@ -1,21 +1,44 @@
 /*A service that provides an arrays of study guides questions and answers to the controller */
-myApp.factory('TestData',  function () {
+myApp.factory('TestData',  function (Score) {
     
     var scienceChp1 = [        
-        [{"question":"What is the periodic law", "answer":"The law that states that the repeating chemical and physical properties of elements change periodically with the atomic number of the element", "userAnswer":"", "completed":false, "graded":false},
-        {"question":"Father of the Periodic table is ", "answer":"Mendeleev", "userAnswer":"", "completed":false, "graded":false},
-        {"question":"Mendeleev arrange the Periodic table by?", "answer":"Atomic Mass", "userAnswer":"", "completed":false, "graded":false},
-        {"question":"Mosley arranged the periodic table according to increasing", "answer":"atomic numbers", "userAnswer":"", "completed":false, "graded":false},
-        {"question":"horizontal rows of periodic table are called", "answer":"periods", "userAnswer":"", "completed":false, "graded":false},
-        {"question":"vertical columns of the periodic able are called", "answer":"roots", "userAnswer":"", "completed":false, "graded":false},
-        {"question":"On the periodic table, Family is another name for a ", "answer":"Group", "userAnswer":"", "completed":false, "graded":false},
-        {"question":"an element that has properties of both metals and nonmetals", "answer":"metalloids", "userAnswer":"", "completed":false, "graded":false},
-        {"question":"What is the classification of most elements on the periodic table", "answer":"Metals", "userAnswer":"", "completed":false, "graded":false},
-        {"question":"Group number and example for Alkali Metals", "answer":"Group 1 & Li, Na, Ls", "userAnswer":"", "completed":false, "graded":false},
+
+        [{"question":"What is the periodic law", "answer":"The law that states that the repeating chemical and physical properties of elements change periodically with the atomic number of the element", "userAnswer":"", "completed":false, "graded":false, "encouragement":""},
+
+        {"question":"Father of the Periodic table is ", "answer":"Mendeleev", "userAnswer":"", "completed":false, "graded":false, "encouragement":""},
+
+        {"question":"Mendeleev arrange the Periodic table by?", "answer":"Atomic Mass", "userAnswer":"", "completed":false, "graded":false, "encouragement":""},
+
+        {"question":"Mosley arranged the periodic table according to increasing", "answer":"atomic numbers", "userAnswer":"", "completed":false, "graded":false, "encouragement":""},
+
+        {"question":"horizontal rows of periodic table are called", "answer":"periods", "userAnswer":"", "completed":false, "graded":false, "encouragement":""},
+
+        {"question":"vertical columns of the periodic able are called", "answer":"roots", "userAnswer":"", "completed":false, "graded":false, "encouragement":""},
+
+        {"question":"On the periodic table, Family is another name for a ", "answer":"Group", "userAnswer":"", "completed":false, "graded":false, "encouragement":""},
+
+        {"question":"an element that has properties of both metals and nonmetals", "answer":"metalloids", "userAnswer":"", "completed":false, "graded":false, "encouragement":""},
+
+        {"question":"What is the classification of most elements on the periodic table", "answer":"Metals", "userAnswer":"", "completed":false, "graded":false, "encouragement":""},
+
+        {"question":"Group number and example for Alkali Metals", "answer":"Group 1 & Li, Na, Ls", "userAnswer":"", "completed":false, "graded":false, "encouragement":""},
+
         ],"Science Chapter 1"
-    ];
+
+    ];	
     
-return {    
+return {
+		//update an exsisting test to include random encouragment
+		upgradeData: function(test){
+			//test if any array of objects matches "test"
+			switch(test){
+				case "scienceChp1":
+					for(var i=0; i<scienceChp1[0].length;i++){
+						scienceChp1[0][i].encouragement = Score.getPositiveFeedBack();
+					}
+					
+			}
+		},	
         //return requested test
         getData: function(test){
             //test if any array of objects matches "test", then return that array


### PR DESCRIPTION
Based on user testing on mobile view when the user user the keyboard the screen is clutter and constricted to a small space. The encouragement information is in the way of seeing the question. 
- In mobile view the encouragement feature is moved to under the question. 
- The "done and reset" buttons is removed and functionality integrated into the enter keyboard command. 
- Instructions to use the enter command is in the encouragement tips and textarea box. 